### PR TITLE
ci: Preliminary support for GitHub merge queues

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -105,6 +105,9 @@ jobs:
       - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
         with:
           shared-key: pulumi-watch-${{ matrix.target }}
+      - name: Apt update
+        run: sudo apt update
+        if: contains(matrix.target, 'linux')
       - name: Add musl tools
         run: sudo apt install -y musl musl-dev musl-tools
         if: endsWith(matrix.target, '-musl')

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -22,5 +22,5 @@ jobs:
       - run: |
           # These vars are format strings.
           # shellcheck disable=SC2016
-          go run github.com/rhysd/actionlint/cmd/actionlint@v1.6.15 \
+          go run github.com/rhysd/actionlint/cmd/actionlint@v1.6.25 \
             -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' -ignore 'SC2016:'

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -46,6 +46,7 @@ jobs:
         run: sha512sum pulumi-watch-* | tee SHA512SUMS
 
       - name: Sign checksums
+        if: false # TODO(https://github.com/pulumi/watchutil-rs/issues/40): This step is currently broken.
         shell: bash
         env:
           RELEASE_KEY: ${{ secrets.RELEASE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Merge
 
 on:
+  merge_group:
   push:
     branches:
       - staging
@@ -30,11 +31,11 @@ jobs:
 
           ./.github/scripts/set-output version "${VERSION}"
       - name: Install git-cliff
-        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+        uses: baptiste0928/cargo-install@30f432979e99f3ea66a8fa2eede53c07063995d8 # v2.1.0
         with:
           crate: git-cliff
-          args: --git https://github.com/AaronFriel/git-cliff --rev 702c79236ef0b0a3d2430f73902db3339933fbfd
-          version: 0.8.1
+          git: https://github.com/AaronFriel/git-cliff
+          commit: 702c79236ef0b0a3d2430f73902db3339933fbfd
       - name: Extract release notes
         id: notes
         shell: bash
@@ -120,7 +121,7 @@ jobs:
     name: Publish
     needs: [test-ok, version-check, info]
     uses: ./.github/workflows/ci-publish.yml
-    if: ${{ github.ref_name == 'staging' }}
+    if: github.ref_name == 'staging' || github.event_name == 'merge_group'
     with:
       version: ${{ needs.info.outputs.version }}
       release_notes: ${{ needs.info.outputs.release_notes }}

--- a/.github/workflows/pr-check-commit-changelog.yml
+++ b/.github/workflows/pr-check-commit-changelog.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install git-cliff
-        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+        uses: baptiste0928/cargo-install@30f432979e99f3ea66a8fa2eede53c07063995d8 # v2.1.0
         with:
           crate: git-cliff
-          args: --git https://github.com/AaronFriel/git-cliff --rev 702c79236ef0b0a3d2430f73902db3339933fbfd
-          version: 0.8.1
+          git: https://github.com/AaronFriel/git-cliff
+          commit: 702c79236ef0b0a3d2430f73902db3339933fbfd
       - name: Changelog
         id: changelog
         env:


### PR DESCRIPTION
It occurred to me that @AaronFriel had setup this repo to test Bors. It would make sense to also use it as a guinea pig for merge queues before landing https://github.com/pulumi/pulumi/pull/13681.