### PR TITLE
Small PR for testing merge queue

### DIFF
--- a/.github/workflows/pr-check-commit-changelog.yml
+++ b/.github/workflows/pr-check-commit-changelog.yml
@@ -45,7 +45,7 @@ jobs:
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
+          comment-author: 'github-actions[bot]'
           body-includes: "# Changelog"
 
       - name: Create or update comment

--- a/.github/workflows/pr-check-commit-changelog.yml
+++ b/.github/workflows/pr-check-commit-changelog.yml
@@ -45,7 +45,7 @@ jobs:
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
+          comment-author: "github-actions[bot]"
           body-includes: "# Changelog"
 
       - name: Create or update comment

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,3 +15,23 @@ jobs:
   unit-test:
     name: Unit Test
     uses: ./.github/workflows/ci-unit-test.yml
+
+  build-ok:
+    name: Build OK
+    needs: [lint, unit-test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo OK
+
+  test-ok:
+    name: Test OK
+    needs: [unit-test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo OK
+
+  publish-ok:
+    name: Publish OK
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No-op on PRs to satisfy branch checks"


### PR DESCRIPTION
This _mostly_ a dummy PR we can try landing while merge queues are
enabled (and Bors is disabled) to confirm everything works as expected.

I needed to tweak the PR job slightly to emit a dummy "Publish OK" step. This is a no-op on PRs but still performs the publish when run in the queue.

Branch protection settings have been updated to no longer restrict merging to Bors, with these settings:
<img width="772" alt="Screenshot 2023-08-10 at 3 21 59 PM" src="https://github.com/pulumi/watchutil-rs/assets/848843/bc6ae693-cf96-4a1f-8a05-629c5c880940">

<img width="772" alt="Screenshot 2023-08-10 at 3 19 56 PM" src="https://github.com/pulumi/watchutil-rs/assets/848843/65d47f85-98e9-4b53-8392-57124bc66454">

After all the checks pass, the merge button looks like this:
<img width="933" alt="Screenshot 2023-08-10 at 3 46 31 PM" src="https://github.com/pulumi/watchutil-rs/assets/848843/591e15ec-145a-4cf5-a59e-03169994044b">

Merging will enqueue a squashed commit.
