### PR TITLE
Remove Bors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
     name: Publish
     needs: [test-ok, version-check, info]
     uses: ./.github/workflows/ci-publish.yml
-    if: github.event_name == 'merge_group'
     with:
       version: ${{ needs.info.outputs.version }}
       release_notes: ${{ needs.info.outputs.release_notes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: Merge
 
 on:
   merge_group:
-  push:
-    branches:
-      - staging
-      - trying
-    tags-ignore:
-      - "*"
 
 jobs:
   info:
@@ -121,7 +115,7 @@ jobs:
     name: Publish
     needs: [test-ok, version-check, info]
     uses: ./.github/workflows/ci-publish.yml
-    if: github.ref_name == 'staging' || github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group'
     with:
       version: ${{ needs.info.outputs.version }}
       release_notes: ${{ needs.info.outputs.release_notes }}

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,0 @@
-delete_merged_branches = true
-update_base_for_deletes = true
-
-status = [
-	'Build OK',
-	'Test OK',
-	'Publish OK',
-]


### PR DESCRIPTION
If this PR merges cleanly it will confirm we will no longer need to use
Bors and can use merge queues instead.

Fixes https://github.com/pulumi/watchutil-rs/issues/35
